### PR TITLE
fix: カルーセルで選択中カードのみリンク遷移するよう修正

### DIFF
--- a/components/home/RotatingCarousel.tsx
+++ b/components/home/RotatingCarousel.tsx
@@ -34,6 +34,8 @@ interface CarouselCardProps {
   scrollY: Animated.SharedValue<number>;
   cardsScale: Animated.SharedValue<number>;
   onPress: () => void;
+  onBackgroundPress: () => void;
+  currentIndex: number;
 }
 
 function CarouselCard({
@@ -43,6 +45,8 @@ function CarouselCard({
   scrollY,
   cardsScale,
   onPress,
+  onBackgroundPress,
+  currentIndex,
 }: CarouselCardProps) {
   const cardHeight = 160;
   const cardSpacing = 60; // 間隔を狭める
@@ -238,10 +242,19 @@ function CarouselCard({
     };
   });
 
+  const handleCardPress = () => {
+    // 選択中のカードのみリンク遷移、それ以外は背景タップと同じ動作
+    if (index === currentIndex) {
+      onPress();
+    } else {
+      onBackgroundPress();
+    }
+  };
+
   return (
     <Animated.View style={[styles.carouselCard, animatedCardStyle]}>
       <Animated.View style={[styles.cardContainer, cardBackgroundStyle]}>
-        <TouchableOpacity onPress={onPress} style={styles.cardTouchable}>
+        <TouchableOpacity onPress={handleCardPress} style={styles.cardTouchable}>
           <View style={styles.cardContent}>
             <View style={styles.header}>
               <View style={styles.textContent}>
@@ -479,6 +492,8 @@ export default function RotatingCarousel({
                     scrollY={scrollY}
                     cardsScale={cardsScale}
                     onPress={() => handleCardPress(link)}
+                    onBackgroundPress={handleBackdropPress}
+                    currentIndex={currentIndex}
                   />
                 ))}
               </TouchableOpacity>


### PR DESCRIPTION
## Summary
- 選択中のカード以外をタップした時はカルーセルを閉じる動作に変更
- CarouselCardPropsにonBackgroundPressとcurrentIndexを追加  
- タップ動作を条件分岐で制御するhandleCardPress関数を実装

## Test plan
- [x] 選択中のカード（中央のカード）をタップした時にリンクに遷移することを確認
- [x] 選択されていないカードをタップした時にカルーセルが閉じることを確認
- [x] スワイプ操作で正常にカードが切り替わることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)