### PR TITLE
feat: カードグループ長押し時の振動フィードバック追加

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import { api } from "@/convex/_generated/api";
 import { useMutation, useQuery } from "convex/react";
+import * as Haptics from "expo-haptics";
 import React, { useMemo, useState } from "react";
 import {
   Alert,
@@ -177,7 +178,8 @@ export default function HomeScreen() {
     );
 
     if (sameDateLinks.length > 1) {
-      // 複数のカードがある場合のみ手札展開
+      // 複数のカードがある場合のみ振動とカルーセル展開
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       setFanExpandedLinks(sameDateLinks);
       setShowFanExpanded(true);
     }


### PR DESCRIPTION
## Summary

カードグループ（複数のカードがある日付グループ）を長押しした際の振動フィードバックを追加してUXを向上させました。

- expo-hapticsを使用してMedium強度の振動を追加
- 単独カードの場合は振動なし（グループでない場合のみ対応）
- カルーセル開始の触覚フィードバックでユーザビリティ向上

## Test plan

- [x] カードグループ（複数カード）の長押しで振動が発生することを確認
- [x] 単独カードの長押しでは振動が発生しないことを確認
- [x] 振動後にカルーセルが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)